### PR TITLE
Add hat support for joysticks.

### DIFF
--- a/src/screen.c
+++ b/src/screen.c
@@ -919,21 +919,24 @@ int drawTimeCenter(int n, int x ,int y, int s, int r, int g, int b) {
 
 int getPadState() {
   int x = 0, y = 0;
+  int hat = SDL_HAT_CENTERED;
   int pad = 0;
   if ( stick != NULL ) {
     x = SDL_JoystickGetAxis(stick, 0);
     y = SDL_JoystickGetAxis(stick, 1);
+    if (SDL_JoystickNumHats(stick) > 0)
+      hat = SDL_JoystickGetHat(stick, 0);
   }
-  if ( keys[SDLK_RIGHT] == SDL_PRESSED || keys[SDLK_KP6] == SDL_PRESSED || x > JOYSTICK_AXIS ) {
+  if ( keys[SDLK_RIGHT] == SDL_PRESSED || keys[SDLK_KP6] == SDL_PRESSED || x > JOYSTICK_AXIS || (hat | SDL_HAT_RIGHT)) {
     pad |= PAD_RIGHT;
   }
-  if ( keys[SDLK_LEFT] == SDL_PRESSED || keys[SDLK_KP4] == SDL_PRESSED || x < -JOYSTICK_AXIS ) {
+  if ( keys[SDLK_LEFT] == SDL_PRESSED || keys[SDLK_KP4] == SDL_PRESSED || x < -JOYSTICK_AXIS || (hat | SDL_HAT_LEFT)) {
     pad |= PAD_LEFT;
   }
-  if ( keys[SDLK_DOWN] == SDL_PRESSED || keys[SDLK_KP2] == SDL_PRESSED || y > JOYSTICK_AXIS ) {
+  if ( keys[SDLK_DOWN] == SDL_PRESSED || keys[SDLK_KP2] == SDL_PRESSED || y > JOYSTICK_AXIS || (hat | SDL_HAT_DOWN)) {
     pad |= PAD_DOWN;
   }
-  if ( keys[SDLK_UP] == SDL_PRESSED ||  keys[SDLK_KP8] == SDL_PRESSED || y < -JOYSTICK_AXIS ) {
+  if ( keys[SDLK_UP] == SDL_PRESSED ||  keys[SDLK_KP8] == SDL_PRESSED || y < -JOYSTICK_AXIS || (hat | SDL_HAT_UP)) {
     pad |= PAD_UP;
   }
   return pad;


### PR DESCRIPTION
I have an arcade controller that doesn't support x/y analog axis, I think this would make it able to work with `rrootage`, but I haven't been able to build with MSVC successfully, do you have build instructions anywhere / could you make a build with this patch applied?